### PR TITLE
Fixed #1 – Updated ZeptoMail host and code as per latest API documentation

### DIFF
--- a/config/zeptomail-driver.php
+++ b/config/zeptomail-driver.php
@@ -2,5 +2,6 @@
 
 return [
     'api_key' =>  env('ZEPTOMAIL_TOKEN'),
-    'host' => env('ZEPTOMAIL_HOST')
+    'host' => env('ZEPTOMAIL_HOST'),
+    'ssl_verify' => env('ZEPTOMAIL_SSL_VERIFY', true),
 ];

--- a/src/LaravelDriverServiceProvider.php
+++ b/src/LaravelDriverServiceProvider.php
@@ -16,13 +16,16 @@ class LaravelDriverServiceProvider extends ServiceProvider
     {
         $this->app->make(MailManager::class)->extend('zeptomail', function (array $config) {
             $config = array_merge($this->app['config']->get('zeptomail-driver', []), $config);
-    
+
+            $clientOptions = [
+                'verify' => Arr::get($config, 'ssl_verify', true), // SSL verification
+            ];
+
             return new ZeptoMailTransport(
                 Arr::get($config, 'api_key'),
-                Arr::get($config, 'host')
+                Arr::get($config, 'host'),
+                $clientOptions,
             );
-    
-            
         });
     
         if ($this->app->runningInConsole()) {

--- a/src/Transport/ZeptoMailTransport.php
+++ b/src/Transport/ZeptoMailTransport.php
@@ -93,8 +93,12 @@ class ZeptoMailTransport implements TransportInterface
      */
     private function getEndpoint(): ?string
     {
+        if (isset($this->domainMapping[$this->host])) {
+            return "https://zeptomail.".$this->domainMapping[$this->host].'/v1.1/email';
+        }
 
-        return "https://zeptomail.".$this->domainMapping[$this->host].'/v1.1/email';
+        return $this->host . '/v1.1/email';
+
     }
         /**
      * @param Email $email

--- a/src/Transport/ZeptoMailTransport.php
+++ b/src/Transport/ZeptoMailTransport.php
@@ -22,13 +22,16 @@ class ZeptoMailTransport implements TransportInterface
 {
     protected string $apikey;
     protected string $host;
+    protected array $clientOptions;
     protected HttpClient $client;
 
-    public function __construct(string $apikey, string $host)
+    public function __construct(string $apikey, string $host, $clientOptions)
     {
         $this->apikey = $apikey;
         $this->host = $host;
-        $this->client = new HttpClient();
+        $this->client = new HttpClient([
+            'verify' => $clientOptions['verify'] ?? true, // SSL verification
+        ]);
     }
 
     public function send(RawMessage $message, Envelope $envelope = null): ?SentMessage


### PR DESCRIPTION
This PR addresses issue #1 

If the value exist in domain mapping use it, else use the provided valye by the user.

Adjusted the integration to match the latest ZeptoMail API documentation: https://www.zoho.com/zeptomail/help/api/email-sending.html

Most developers rely on these two documents for Laravel integration:
https://www.zoho.com/zeptomail/help/laravel-integration.html
https://www.zoho.com/zeptomail/help/api/email-sending.html

However, the values and examples between the docs and dashboard aren't consistent. For example, the dashboard clearly shows the host value but that doesn't work when to set it for ZEPTOMAIL_HOST.

ZeptoMail dashboard screensho for API integration: 
<img width="729" height="531" alt="image" src="https://github.com/user-attachments/assets/e01ff100-5a85-48e9-b2b9-a3ca1a0f3899" />


✅ Example .env configuration after this change:

```
ZEPTOMAIL_HOST=api.zeptomail.in
ZEPTOMAIL_TOKEN="SEND_MAIL_TOKEN"

MAIL_MAILER=zeptomail
MAIL_FROM_ADDRESS=invoice@zylker.com 
MAIL_FROM_NAME="App Name"
```


I’ve tested the changes and confirmed that email sending works as expected.

Also, happy to help maintain this repo going forward if you're open to it. Let me know.

Thanks!