### PR TITLE
feat: support Laravel 13 (Illuminate ^13.0)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.0",
         "ext-json": "*",
-        "illuminate/support": "^9.0 || ^10.0  || ^11.0 || ^12.0",
+        "illuminate/support": "^9.0 || ^10.0  || ^11.0 || ^12.0 || ^13.0"",
         "nyholm/psr7": "^1.5",
         "php-http/guzzle7-adapter": "^1.0",
         "symfony/mailer": "^6.0 || ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require": {
         "php": ">=8.0",
         "ext-json": "*",
-        "illuminate/support": "^9.0 || ^10.0  || ^11.0 || ^12.0 || ^13.0"",
+        "illuminate/support": "^9.0 || ^10.0  || ^11.0 || ^12.0 || ^13.0",
         "nyholm/psr7": "^1.5",
         "php-http/guzzle7-adapter": "^1.0",
         "symfony/mailer": "^6.0 || ^7.0"


### PR DESCRIPTION
## Description
This Pull Request updates the version constraints in `composer.json` to include support for Laravel 13 (Illuminate ^13.0).

## Why?
Laravel 13 has been released, and current users of this package cannot upgrade their projects because of the strict version constraint on `illuminate/support`.

## Changes
- Updated `illuminate/support` version to `^9.0 || ^10.0 || ^11.0 || ^12.0 || ^13.0`.